### PR TITLE
Add audience section with glassmorphic columns

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -152,6 +152,57 @@ main {
     }
 }
 
+/* Audience section */
+.audience-grid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 2rem;
+    max-width: 1000px;
+    margin: 0 auto;
+    width: 100%;
+}
+
+.audience-card {
+    background: rgba(255, 255, 255, 0.10);
+    border: 1.5px solid rgba(255, 255, 255, 0.25);
+    border-radius: 24px;
+    padding: 2rem;
+    box-shadow: 0 8px 32px 0 rgba(31, 38, 135, 0.10);
+    backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
+}
+
+.audience-title {
+    color: var(--gold-light);
+    text-align: center;
+    margin-bottom: 1rem;
+    font-size: 1.6rem;
+}
+
+.audience-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+.audience-list li {
+    position: relative;
+    padding-left: 2rem;
+    margin-bottom: 0.8rem;
+}
+.audience-list li::before {
+    position: absolute;
+    left: 0;
+    top: 0;
+}
+.yes-list li::before { content: "✔️"; }
+.no-list li::before { content: "❌"; }
+
+@media (max-width: 900px) {
+    .audience-grid {
+        grid-template-columns: 1fr;
+    }
+}
+
 /* Centrar video y formato horizontal */
 .video-explain {
     display: flex;

--- a/index.html
+++ b/index.html
@@ -42,6 +42,27 @@
                 <p class="empathy-text">Pero hay momentos en los que uno simplemente quiere entender mejor a su cuerpo. Sin dolor. Sin tanto trámite. Sin sentirse como un expediente más.</p>
             </div>
         </section>
+        <!-- PARA QUIÉN ES -->
+        <section class="section audience-section">
+            <div class="container audience-grid">
+                <div class="audience-card audience-yes">
+                    <h3 class="audience-title">Esto es para ti</h3>
+                    <ul class="audience-list yes-list">
+                        <li>Quieres comprender mejor tu salud de forma preventiva</li>
+                        <li>Buscas alternativas sin dolor ni trámites complicados</li>
+                        <li>Estás dispuest@ a tomar acción para mejorar tu bienestar</li>
+                    </ul>
+                </div>
+                <div class="audience-card audience-no">
+                    <h3 class="audience-title">No es para ti</h3>
+                    <ul class="audience-list no-list">
+                        <li>Esperas un diagnóstico médico tradicional</li>
+                        <li>No estás dispuest@ a cambiar tus hábitos actuales</li>
+                        <li>Prefieres tratamientos invasivos o medicamentosos</li>
+                    </ul>
+                </div>
+            </div>
+        </section>
         <!-- SOLUCIÓN -->
         <section id="solucion" class="section solution">
             <div class="container">


### PR DESCRIPTION
## Summary
- add new "para quién es" section after empathy block in `index.html`
- create two bullet list columns for who the service is for / not for
- style the new section with glassmorphism and icon bullets in `css/styles.css`
- ensure columns stack vertically on small screens

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686d7e7bacb0832b82d0c6f01c7c21fb